### PR TITLE
Validate field values

### DIFF
--- a/lib/chrono/fields/base.rb
+++ b/lib/chrono/fields/base.rb
@@ -1,6 +1,15 @@
 module Chrono
   module Fields
     class Base
+      class InvalidField < StandardError
+        attr_reader :source
+
+        def initialize(message, source)
+          super("#{message}: #{source}")
+          @source = source
+        end
+      end
+
       attr_reader :source
 
       def initialize(source)
@@ -11,7 +20,11 @@ module Chrono
         if has_multiple_elements?
           fields.map(&:to_a).flatten.uniq.sort
         else
-          lower.step(upper, step).to_a.sort
+          ary = lower.step(upper, step).to_a
+          if ary.empty?
+            raise InvalidField.new('The range is evaluated to empty', source)
+          end
+          ary.sort
         end
       end
 

--- a/lib/chrono/fields/base.rb
+++ b/lib/chrono/fields/base.rb
@@ -20,11 +20,7 @@ module Chrono
         if has_multiple_elements?
           fields.map(&:to_a).flatten.uniq.sort
         else
-          ary = lower.step(upper, step).to_a
-          if ary.empty?
-            raise InvalidField.new('The range is evaluated to empty', source)
-          end
-          ary.sort
+          from_range
         end
       end
 
@@ -32,6 +28,18 @@ module Chrono
 
       def interpolated
         source.gsub("*", "#{range.first}-#{range.last}")
+      end
+
+      def from_range
+        if lower < range.begin || range.end < upper
+          raise InvalidField.new('The field is out-of-range', source)
+        end
+
+        ary = lower.step(upper, step).to_a
+        if ary.empty?
+          raise InvalidField.new('The range is evaluated to empty', source)
+        end
+        ary.sort
       end
 
       def lower

--- a/lib/chrono/fields/base.rb
+++ b/lib/chrono/fields/base.rb
@@ -59,7 +59,11 @@ module Chrono
       end
 
       def match_data
-        @match_data ||= interpolated.match(pattern)
+        @match_data ||= interpolated.match(pattern).tap do |m|
+          unless m
+            raise InvalidField.new('Unparsable field', source)
+          end
+        end
       end
 
       def elements

--- a/spec/chrono/iterator_spec.rb
+++ b/spec/chrono/iterator_spec.rb
@@ -32,6 +32,14 @@ describe Chrono::Iterator do
         expect { described_class.new('5-0 * * * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
       end
 
+      it 'raises error when too large upper is given' do
+        expect { described_class.new('5-60 * * * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
+      end
+
+      it 'raises error when too low lower is given' do
+        expect { described_class.new('* * 0 * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
+      end
+
       it 'raises error when unparsable field is given' do
         expect { described_class.new('a-z * * * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
       end

--- a/spec/chrono/iterator_spec.rb
+++ b/spec/chrono/iterator_spec.rb
@@ -27,6 +27,10 @@ describe Chrono::Iterator do
         now = Time.parse(from)
         described_class.new(source, now: now).next.should == Time.parse(to)
       end
+
+      it 'raises error when empty range is given' do
+        expect { described_class.new('5-0 * * * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
+      end
     end
   end
 end

--- a/spec/chrono/iterator_spec.rb
+++ b/spec/chrono/iterator_spec.rb
@@ -31,6 +31,10 @@ describe Chrono::Iterator do
       it 'raises error when empty range is given' do
         expect { described_class.new('5-0 * * * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
       end
+
+      it 'raises error when unparsable field is given' do
+        expect { described_class.new('a-z * * * *').next }.to raise_error(Chrono::Fields::Base::InvalidField)
+      end
     end
   end
 end


### PR DESCRIPTION
When the given fields is invalid, `Chrono::Iterator#next` could fall into an infinite loop.
e.g. `Chrono::Iterator.new('5-0 * * * *').next` .

This pull request guards `Chrono::Iterator#next` from infinite loops by validating field values before calculating the next time.
