### PR TITLE
Require whole active_support to support ActiveSupport v7

### DIFF
--- a/chrono.gemspec
+++ b/chrono.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activesupport", '>= 5.2'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.4.0"

--- a/lib/chrono/next_time.rb
+++ b/lib/chrono/next_time.rb
@@ -1,13 +1,5 @@
+require "active_support"
 require "active_support/core_ext/numeric/time"
-require "active_support/version"
-
-if ActiveSupport::VERSION::MAJOR >= 4
-  require "active_support/core_ext/date"
-  require "active_support/core_ext/time"
-else
-  require "active_support/core_ext/date/calculations"
-  require "active_support/core_ext/time/calculations"
-end
 
 module Chrono
   class NextTime


### PR DESCRIPTION
On ActiveSupport v7, raises this exeption when require minimum file.

```
uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState (NameError)
```

* https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support
* https://github.com/rails/rails/pull/43852

And, ActiveSupport v4 is deprecated now. So remove if-else of version.